### PR TITLE
Fix the link for the Depfu badge (SVG image)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Build Status](https://api.travis-ci.org/fsi-tue/cyberauftritt.svg?branch=master)](https://travis-ci.org/fsi-tue/cyberauftritt)
 [![License](https://img.shields.io/github/license/fsi-tue/cyberauftritt.svg)](https://github.com/fsi-tue/cyberauftritt/blob/master/LICENSE.txt)
-[![Depfu](https://badges.depfu.com/badges/f0364df208541d4fbae91bef9446037b/overview.svg)](https://depfu.com/github/fsi-tue/cyberauftritt)
+[![Depfu](https://img.shields.io/depfu/fsi-tue/cyberauftritt.svg)](https://depfu.com/github/fsi-tue/cyberauftritt)
 
 Zukünftige Website der Fachschaft Informatik Tübingen.
 


### PR DESCRIPTION
Missed that link in 61df8ce6c19ce2c52954170d17d5f5f3f24ceb7b (probably
due to the hash).

--

Ergebnis sieht man hier: https://github.com/primeos/cyberauftritt (stale -> latest).