### PR TITLE
Travis: Enable caching and upgrade Ruby

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,21 @@
+sudo: false
+
 language: ruby
 rvm:
-- 2.3.3
+- 2.5
+
+cache: bundler
+
 addons:
   apt:
     packages:
     - libcurl4-openssl-dev # Required to avoid TLS errors
 
-script:
-  - set -e # halt script on error
-  - bundle exec jekyll build
-  - bundle exec htmlproofer ./_site
-
 env:
   global:
   - NOKOGIRI_USE_SYSTEM_LIBRARIES=true # speeds up installation of html-proofer
 
-sudo: false
+script:
+  - set -e # halt script on error
+  - bundle exec jekyll build
+  - bundle exec htmlproofer ./_site


### PR DESCRIPTION
The current stable version of Ruby is 2.5.1:
https://www.ruby-lang.org/en/downloads/

Enabling caching should provide minor performance improvements.