### PR TITLE
Word breaks for a better mobile view

### DIFF
--- a/css/main.css
+++ b/css/main.css
@@ -20,10 +20,12 @@ body {
 p {
   line-height: 1.5;
   margin: 30px 0;
+  word-break: break-word;
 }
 h1,h2,h3,h4,h5,h6 {
   font-family: 'Open Sans', 'Helvetica Neue', Helvetica, Arial, sans-serif;
   font-weight: 800;
+  word-break: break-word;
 }
 a {
   color: {{ site.link-col }};


### PR DESCRIPTION
This PR adds word breaks to the h* and p css tags. 
This displays long words (mostly headings) correctly on mobile devices.